### PR TITLE
Enable codecov integration for PR coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,6 @@ jobs:
           fi
 
       - name: Upload coverage reports
-        if: false  # Disabled until we have actual test coverage
         uses: codecov/codecov-action@v4
         with:
           directory: ./coverage


### PR DESCRIPTION
- Remove 'if: false' condition from codecov upload step
- Coverage reports will now be automatically uploaded to codecov on PRs
- Requires CODECOV_TOKEN to be set in GitHub repository secrets